### PR TITLE
feat: revert blocks

### DIFF
--- a/service/cronjob/monitor/monitor/monitorGenericBlocks.go
+++ b/service/cronjob/monitor/monitor/monitorGenericBlocks.go
@@ -154,6 +154,7 @@ func (m *Monitor) MonitorGenericBlocks() (err error) {
 			relatedBlocks[blockHeight].BlockStatus = block.StatusVerifiedAndExecuted
 		case zkbasLogBlocksRevertSigHash.Hex():
 			l1EventInfo.EventType = EventTypeRevertedBlock
+			// TODO revert
 		default:
 		}
 


### PR DESCRIPTION
### Description
Supports the overall state of L2 to revert to a specific height.

Since all `accounts`, `liquidity`, and `nft` will keep historical records according to each height, we can quickly use these tables to restore the state of the specified height and delete the executed tx and block data at the same time.

### RelatedTable

1. block
2. block_for_commit
3. tx
4. tx_detail
5. account_history
6. liquidity_history
7. l2_nft_history
8. mempool_tx
9. account
10. liquidity
11. l2_nft

### Program

1. monitor subscribes `BlocksRevert` event.
2. get revert height from the event.
3. delete `block`, `block_for_commit `, `tx`, and `tx_detal` content that is higher than the reverted height.
4. delete `account_history`, `liquidity_history`, and `l2_nft_history` content that is higher than the reverted height.
5. delete `mempool_tx` content that is higher than the reverted height.
6. get `account`, `liquidity`, and `l2 nft` from history table and update.
7. reset caches.
8. rollback the smt to the reverted height.

### Note
1. The oldest version of smt only supports block heights marked with `Verify`. If you want to revert to the height before it was marked `Verify`, the tree must be rebuilt from the history table.

### Ref
1. https://github.com/Zecrey-Labs/zecrey-legend/pull/274
2. https://github.com/Zecrey-Labs/zecrey-legend/pull/284
3. https://github.com/Zecrey-Labs/zecrey-legend/pull/285
