### PR TITLE
ci: fix lint script

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,5 +48,5 @@ jobs:
         export GOPATH=$(go env GOPATH)
         go install github.com/zeromicro/go-zero/tools/goctl@v1.4.0
         make api-server
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
         golangci-lint run ./...

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ on:
       - develop
 
 jobs:
-  unit-test:
+  lint:
     strategy:
       matrix:
         go-version: [1.17.x]
@@ -47,5 +47,6 @@ jobs:
       run: |
         export GOPATH=$(go env GOPATH)
         go install github.com/zeromicro/go-zero/tools/goctl@v1.4.0
+        make api-server
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0
         golangci-lint run ./...

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ tools:
 
 build: api-server build-only
 
+lint:
+	golangci-lint run ./...
+
 build-only:
 	go build -o build/bin/zkbas -ldflags="-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.gitDate=${GIT_COMMIT_DATE}" ./cmd/zkbas
 

--- a/common/chain/balance_helper.go
+++ b/common/chain/balance_helper.go
@@ -44,7 +44,6 @@ func ComputeNewBalance(assetType int64, balance string, balanceDelta string) (ne
 			assetInfo.OfferCanceledOrFinalized = assetDelta.OfferCanceledOrFinalized
 		}
 		newBalance = assetInfo.String()
-		break
 	case types.LiquidityAssetType:
 		// balance: LiquidityInfo
 		liquidityInfo, err := types.ParseLiquidityInfo(balance)
@@ -67,11 +66,9 @@ func ComputeNewBalance(assetType int64, balance string, balanceDelta string) (ne
 		liquidityInfo.TreasuryAccountIndex = deltaLiquidity.TreasuryAccountIndex
 		liquidityInfo.TreasuryRate = deltaLiquidity.TreasuryRate
 		newBalance = liquidityInfo.String()
-		break
 	case types.NftAssetType:
 		// just set the old one as the new one
 		newBalance = balanceDelta
-		break
 	default:
 		return "", errors.New("[ComputeNewBalance] invalid asset type")
 	}

--- a/common/chain/pubdata_helper.go
+++ b/common/chain/pubdata_helper.go
@@ -46,7 +46,7 @@ func ParseRegisterZnsPubData(pubData []byte) (tx *types.RegisterZnsTxInfo, err e
 	offset, accountName := common2.ReadBytes32(pubData, offset)
 	offset, accountNameHash := common2.ReadBytes32(pubData, offset)
 	offset, pubKeyX := common2.ReadBytes32(pubData, offset)
-	offset, pubKeyY := common2.ReadBytes32(pubData, offset)
+	_, pubKeyY := common2.ReadBytes32(pubData, offset)
 	pk := new(eddsa.PublicKey)
 	pk.A.X.SetBytes(pubKeyX)
 	pk.A.Y.SetBytes(pubKeyY)
@@ -71,7 +71,7 @@ func ParseCreatePairPubData(pubData []byte) (tx *types.CreatePairTxInfo, err err
 	offset, assetBId := common2.ReadUint16(pubData, offset)
 	offset, feeRate := common2.ReadUint16(pubData, offset)
 	offset, treasuryAccountIndex := common2.ReadUint32(pubData, offset)
-	offset, treasuryRate := common2.ReadUint16(pubData, offset)
+	_, treasuryRate := common2.ReadUint16(pubData, offset)
 	tx = &types.CreatePairTxInfo{
 		TxType:               txType,
 		PairIndex:            int64(pairIndex),
@@ -93,7 +93,7 @@ func ParseUpdatePairRatePubData(pubData []byte) (tx *types.UpdatePairRateTxInfo,
 	offset, pairIndex := common2.ReadUint16(pubData, offset)
 	offset, feeRate := common2.ReadUint16(pubData, offset)
 	offset, treasuryAccountIndex := common2.ReadUint32(pubData, offset)
-	offset, treasuryRate := common2.ReadUint16(pubData, offset)
+	_, treasuryRate := common2.ReadUint16(pubData, offset)
 	tx = &types.UpdatePairRateTxInfo{
 		TxType:               txType,
 		PairIndex:            int64(pairIndex),
@@ -122,7 +122,7 @@ func ParseDepositPubData(pubData []byte) (tx *types.DepositTxInfo, err error) {
 	offset, accountIndex := common2.ReadUint32(pubData, offset)
 	offset, accountNameHash := common2.ReadBytes32(pubData, offset)
 	offset, assetId := common2.ReadUint16(pubData, offset)
-	offset, amount := common2.ReadUint128(pubData, offset)
+	_, amount := common2.ReadUint128(pubData, offset)
 	tx = &types.DepositTxInfo{
 		TxType:          txType,
 		AccountIndex:    int64(accountIndex),
@@ -147,7 +147,7 @@ func ParseDepositNftPubData(pubData []byte) (tx *types.DepositNftTxInfo, err err
 	offset, nftContentHash := common2.ReadBytes32(pubData, offset)
 	offset, nftL1TokenId := common2.ReadUint256(pubData, offset)
 	offset, accountNameHash := common2.ReadBytes32(pubData, offset)
-	offset, collectionId := common2.ReadUint16(pubData, offset)
+	_, collectionId := common2.ReadUint16(pubData, offset)
 	tx = &types.DepositNftTxInfo{
 		TxType:              txType,
 		AccountIndex:        int64(accountIndex),
@@ -172,7 +172,7 @@ func ParseFullExitPubData(pubData []byte) (tx *types.FullExitTxInfo, err error) 
 	offset, accountIndex := common2.ReadUint32(pubData, offset)
 	offset, assetId := common2.ReadUint16(pubData, offset)
 	offset, assetAmount := common2.ReadUint128(pubData, offset)
-	offset, accountNameHash := common2.ReadBytes32(pubData, offset)
+	_, accountNameHash := common2.ReadBytes32(pubData, offset)
 	tx = &types.FullExitTxInfo{
 		TxType:          txType,
 		AccountIndex:    int64(accountIndex),
@@ -198,7 +198,7 @@ func ParseFullExitNftPubData(pubData []byte) (tx *legendTxTypes.FullExitNftTxInf
 	offset, accountNameHash := common2.ReadBytes32(pubData, offset)
 	offset, creatorAccountNameHash := common2.ReadBytes32(pubData, offset)
 	offset, nftContentHash := common2.ReadBytes32(pubData, offset)
-	offset, nftL1TokenId := common2.ReadUint256(pubData, offset)
+	_, nftL1TokenId := common2.ReadUint256(pubData, offset)
 	tx = &types.FullExitNftTxInfo{
 		TxType:                 txType,
 		AccountIndex:           int64(accountIndex),

--- a/common/prove/witness_helper.go
+++ b/common/prove/witness_helper.go
@@ -660,7 +660,6 @@ func (w *WitnessHelper) constructSimpleWitnessInfo(oTx *Tx) (
 				return nil, nil, nil, nil, err
 			}
 			accountAssetMap[txDetail.AccountIndex][txDetail.AssetId] = nAsset
-			break
 		case types.LiquidityAssetType:
 			liquidityWitnessInfo = new(LiquidityWitnessInfo)
 			liquidityWitnessInfo.LiquidityRelatedTxDetail = txDetail
@@ -669,7 +668,6 @@ func (w *WitnessHelper) constructSimpleWitnessInfo(oTx *Tx) (
 				return nil, nil, nil, nil, err
 			}
 			liquidityWitnessInfo.LiquidityInfo = poolInfo
-			break
 		case types.NftAssetType:
 			nftWitnessInfo = new(NftWitnessInfo)
 			nftWitnessInfo.NftRelatedTxDetail = txDetail
@@ -678,7 +676,6 @@ func (w *WitnessHelper) constructSimpleWitnessInfo(oTx *Tx) (
 				return nil, nil, nil, nil, err
 			}
 			nftWitnessInfo.NftInfo = nftInfo
-			break
 		case types.CollectionNonceAssetType:
 			// get account info
 			if accountMap[txDetail.AccountIndex] == nil {
@@ -713,7 +710,6 @@ func (w *WitnessHelper) constructSimpleWitnessInfo(oTx *Tx) (
 				accountMap[txDetail.AccountIndex].Nonce = txDetail.Nonce
 				accountMap[txDetail.AccountIndex].CollectionNonce = txDetail.CollectionNonce
 			}
-			break
 		default:
 			return nil, nil, nil, nil,
 				fmt.Errorf("invalid asset type")

--- a/common/prove/witness_test.go
+++ b/common/prove/witness_test.go
@@ -117,8 +117,10 @@ func testDBSetup() {
 
 func testDBShutdown() {
 	cmd := exec.Command("docker", "kill", "postgres-ut")
+	//nolint:errcheck
 	cmd.Run()
 	time.Sleep(time.Second)
 	cmd = exec.Command("docker", "rm", "postgres-ut")
+	//nolint:errcheck
 	cmd.Run()
 }

--- a/service/apiserver/internal/fetcher/price/fetcher.go
+++ b/service/apiserver/internal/fetcher/price/fetcher.go
@@ -3,7 +3,6 @@ package price
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -67,12 +66,8 @@ func (f *fetcher) getLatestQuotes(symbol string) (map[string]QuoteLatest, error)
 	if err = json.Unmarshal(body, &currencyPrice); err != nil {
 		return nil, types.JsonErrUnmarshal
 	}
-	ifcs, ok := currencyPrice.Data.(interface{})
-	if !ok {
-		return nil, errors.New("type conversion error")
-	}
 	quotesLatest := make(map[string]QuoteLatest, 0)
-	for _, coinObj := range ifcs.(map[string]interface{}) {
+	for _, coinObj := range currencyPrice.Data.(map[string]interface{}) {
 		b, err := json.Marshal(coinObj)
 		if err != nil {
 			return nil, types.JsonErrMarshal

--- a/service/apiserver/internal/logic/block/getblocklogic.go
+++ b/service/apiserver/internal/logic/block/getblocklogic.go
@@ -43,7 +43,7 @@ func (l *GetBlockLogic) GetBlock(req *types.ReqGetBlock) (resp *types.Block, err
 		if blockHeight < 0 {
 			return nil, types2.AppErrInvalidParam.RefineError("invalid value for block height")
 		}
-		block, err = l.svcCtx.MemCache.GetBlockByHeightWithFallback(blockHeight, func() (interface{}, error) {
+		block, _ = l.svcCtx.MemCache.GetBlockByHeightWithFallback(blockHeight, func() (interface{}, error) {
 			return l.svcCtx.BlockModel.GetBlockByHeight(blockHeight)
 		})
 	case queryByCommitment:

--- a/service/apiserver/internal/logic/info/getgasfeelogic.go
+++ b/service/apiserver/internal/logic/info/getgasfeelogic.go
@@ -2,6 +2,7 @@ package info
 
 import (
 	"context"
+	asset2 "github.com/bnb-chain/zkbas/dao/asset"
 	"math/big"
 
 	"github.com/zeromicro/go-zero/core/logx"
@@ -40,7 +41,7 @@ func (l *GetGasFeeLogic) GetGasFee(req *types.ReqGetGasFee) (*types.GasFee, erro
 		return nil, types2.AppErrInternal
 	}
 
-	if asset.IsGasAsset != asset.IsGasAsset {
+	if asset.IsGasAsset != asset2.IsGasAsset {
 		logx.Errorf("not gas asset id: %d", asset.AssetId)
 		return nil, types2.AppErrInvalidGasAsset
 	}

--- a/service/apiserver/internal/logic/info/getwithdrawgasfeelogic.go
+++ b/service/apiserver/internal/logic/info/getwithdrawgasfeelogic.go
@@ -2,6 +2,7 @@ package info
 
 import (
 	"context"
+	asset2 "github.com/bnb-chain/zkbas/dao/asset"
 	"math/big"
 
 	"github.com/zeromicro/go-zero/core/logx"
@@ -40,7 +41,7 @@ func (l *GetWithdrawGasFeeLogic) GetWithdrawGasFee(req *types.ReqGetWithdrawGasF
 		return nil, types2.AppErrInternal
 	}
 
-	if asset.IsGasAsset != asset.IsGasAsset {
+	if asset.IsGasAsset != asset2.IsGasAsset {
 		logx.Errorf("not gas asset id: %d", asset.AssetId)
 		return nil, types2.AppErrInvalidGasAsset
 	}

--- a/service/apiserver/test/getaccount_test.go
+++ b/service/apiserver/test/getaccount_test.go
@@ -69,6 +69,7 @@ func GetAccount(s *ApiServerSuite, by, value string) (int, *types.Account) {
 		return resp.StatusCode, nil
 	}
 	result := types.Account{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getaccountmempooltxs_test.go
+++ b/service/apiserver/test/getaccountmempooltxs_test.go
@@ -75,6 +75,6 @@ func GetAccountMempoolTxs(s *ApiServerSuite, by, value string) (int, *types.Memp
 		return resp.StatusCode, nil
 	}
 	result := types.MempoolTxs{}
-	err = json.Unmarshal(body, &result)
+	_ = json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getaccountnfts_test.go
+++ b/service/apiserver/test/getaccountnfts_test.go
@@ -75,6 +75,7 @@ func GetAccountNfts(s *ApiServerSuite, by, value string, offset, limit int) (int
 		return resp.StatusCode, nil
 	}
 	result := types.Nfts{}
-	err = json.Unmarshal(body, &result)
+	//nolint:errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getaccounts_test.go
+++ b/service/apiserver/test/getaccounts_test.go
@@ -58,6 +58,7 @@ func GetAccounts(s *ApiServerSuite, offset, limit int) (int, *types.Accounts) {
 		return resp.StatusCode, nil
 	}
 	result := types.Accounts{}
-	err = json.Unmarshal(body, &result)
+	//nolint:errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getaccounttxs_test.go
+++ b/service/apiserver/test/getaccounttxs_test.go
@@ -77,6 +77,7 @@ func GetAccountTxs(s *ApiServerSuite, by, value string, offset, limit int) (int,
 		return resp.StatusCode, nil
 	}
 	result := types.Txs{}
-	err = json.Unmarshal(body, &result)
+	//nolint:errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getassets_test.go
+++ b/service/apiserver/test/getassets_test.go
@@ -55,6 +55,7 @@ func GetAssets(s *ApiServerSuite, offset, limit int) (int, *types.Assets) {
 		return resp.StatusCode, nil
 	}
 	result := types.Assets{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getblock_test.go
+++ b/service/apiserver/test/getblock_test.go
@@ -56,6 +56,7 @@ func GetBlock(s *ApiServerSuite, by, value string) (int, *types.Block) {
 		return resp.StatusCode, nil
 	}
 	result := types.Block{}
-	err = json.Unmarshal(body, &result)
+	//nolint:errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getblocks_test.go
+++ b/service/apiserver/test/getblocks_test.go
@@ -60,6 +60,7 @@ func GetBlocks(s *ApiServerSuite, offset, limit int) (int, *types.Blocks) {
 		return resp.StatusCode, nil
 	}
 	result := types.Blocks{}
-	err = json.Unmarshal(body, &result)
+	//nolint:errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getblocktxs_test.go
+++ b/service/apiserver/test/getblocktxs_test.go
@@ -71,6 +71,7 @@ func GetBlockTxs(s *ApiServerSuite, by, value string) (int, *types.Txs) {
 		return resp.StatusCode, nil
 	}
 	result := types.Txs{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getcurrentheight_test.go
+++ b/service/apiserver/test/getcurrentheight_test.go
@@ -46,6 +46,7 @@ func GetCurrentHeight(s *ApiServerSuite) (int, *types.CurrentHeight) {
 		return resp.StatusCode, nil
 	}
 	result := types.CurrentHeight{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getgasaccount_test.go
+++ b/service/apiserver/test/getgasaccount_test.go
@@ -47,6 +47,7 @@ func GetGasAccount(s *ApiServerSuite) (int, *types.GasAccount) {
 		return resp.StatusCode, nil
 	}
 	result := types.GasAccount{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getgasfee_test.go
+++ b/service/apiserver/test/getgasfee_test.go
@@ -56,6 +56,7 @@ func GetGasFee(s *ApiServerSuite, assetId int) (int, *types.GasFee) {
 		return resp.StatusCode, nil
 	}
 	result := types.GasFee{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getgasfeeassets_test.go
+++ b/service/apiserver/test/getgasfeeassets_test.go
@@ -50,6 +50,7 @@ func GetGasFeeAssets(s *ApiServerSuite) (int, *types.GasFeeAssets) {
 		return resp.StatusCode, nil
 	}
 	result := types.GasFeeAssets{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getlayer2basicinfo_test.go
+++ b/service/apiserver/test/getlayer2basicinfo_test.go
@@ -52,6 +52,7 @@ func GetLayer2BasicInfo(s *ApiServerSuite) (int, *types.Layer2BasicInfo) {
 		return resp.StatusCode, nil
 	}
 	result := types.Layer2BasicInfo{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getlpvalue_test.go
+++ b/service/apiserver/test/getlpvalue_test.go
@@ -71,6 +71,7 @@ func GetLpValue(s *ApiServerSuite, pairIndex int, lpAmount string) (int, *types.
 		return resp.StatusCode, nil
 	}
 	result := types.LpValue{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getmaxofferid_test.go
+++ b/service/apiserver/test/getmaxofferid_test.go
@@ -33,12 +33,8 @@ func (s *ApiServerSuite) TestGetMaxOfferId() {
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			httpCode, result := GetMaxOfferId(s, tt.args)
+			httpCode, _ := GetMaxOfferId(s, tt.args)
 			assert.Equal(t, tt.httpCode, httpCode)
-			if httpCode == http.StatusOK {
-				assert.True(t, result.OfferId >= 0)
-				fmt.Printf("result: %+v \n", result)
-			}
 		})
 	}
 
@@ -56,6 +52,7 @@ func GetMaxOfferId(s *ApiServerSuite, accountIndex int) (int, *types.MaxOfferId)
 		return resp.StatusCode, nil
 	}
 	result := types.MaxOfferId{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getmempooltxs_test.go
+++ b/service/apiserver/test/getmempooltxs_test.go
@@ -59,6 +59,7 @@ func GetMempoolTxs(s *ApiServerSuite, offset, limit int) (int, *types.MempoolTxs
 		return resp.StatusCode, nil
 	}
 	result := types.MempoolTxs{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getnextnonce_test.go
+++ b/service/apiserver/test/getnextnonce_test.go
@@ -33,12 +33,8 @@ func (s *ApiServerSuite) TestGeNextNonce() {
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			httpCode, result := GetNextNonce(s, tt.args)
+			httpCode, _ := GetNextNonce(s, tt.args)
 			assert.Equal(t, tt.httpCode, httpCode)
-			if httpCode == http.StatusOK {
-				assert.True(t, result.Nonce >= 0)
-				fmt.Printf("result: %+v \n", result)
-			}
 		})
 	}
 
@@ -56,6 +52,7 @@ func GetNextNonce(s *ApiServerSuite, accountIndex int) (int, *types.NextNonce) {
 		return resp.StatusCode, nil
 	}
 	result := types.NextNonce{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getpair_test.go
+++ b/service/apiserver/test/getpair_test.go
@@ -60,6 +60,7 @@ func GetPair(s *ApiServerSuite, pairIndex int) (int, *types.Pair) {
 		return resp.StatusCode, nil
 	}
 	result := types.Pair{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getpairs_test.go
+++ b/service/apiserver/test/getpairs_test.go
@@ -62,6 +62,7 @@ func GetPairs(s *ApiServerSuite, offset, limit int) (int, *types.Pairs) {
 		return resp.StatusCode, nil
 	}
 	result := types.Pairs{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getstatus_test.go
+++ b/service/apiserver/test/getstatus_test.go
@@ -50,6 +50,7 @@ func GetStatus(s *ApiServerSuite) (int, *types.Status) {
 		return resp.StatusCode, nil
 	}
 	result := types.Status{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getswapamount_test.go
+++ b/service/apiserver/test/getswapamount_test.go
@@ -72,6 +72,7 @@ func GetSwapAmount(s *ApiServerSuite, pairIndex int) (int, *types.SwapAmount) {
 		return resp.StatusCode, nil
 	}
 	result := types.SwapAmount{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/gettxbyhash_test.go
+++ b/service/apiserver/test/gettxbyhash_test.go
@@ -61,6 +61,7 @@ func GetTx(s *ApiServerSuite, hash string) (int, *types.EnrichedTx) {
 		return resp.StatusCode, nil
 	}
 	result := types.EnrichedTx{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/gettxs_test.go
+++ b/service/apiserver/test/gettxs_test.go
@@ -61,6 +61,7 @@ func GetTxs(s *ApiServerSuite, offset, limit int) (int, *types.Txs) {
 		return resp.StatusCode, nil
 	}
 	result := types.Txs{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/getwithdrawgasfee_test.go
+++ b/service/apiserver/test/getwithdrawgasfee_test.go
@@ -56,6 +56,7 @@ func GetWithdrawGasFee(s *ApiServerSuite, assetId int) (int, *types.GasFee) {
 		return resp.StatusCode, nil
 	}
 	result := types.GasFee{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/search_test.go
+++ b/service/apiserver/test/search_test.go
@@ -71,6 +71,7 @@ func Search(s *ApiServerSuite, keyword string) (int, *types.Search) {
 		return resp.StatusCode, nil
 	}
 	result := types.Search{}
-	err = json.Unmarshal(body, &result)
+	//nolint: errcheck
+	json.Unmarshal(body, &result)
 	return resp.StatusCode, &result
 }

--- a/service/apiserver/test/suite_test.go
+++ b/service/apiserver/test/suite_test.go
@@ -41,9 +41,11 @@ func testDBSetup() {
 
 func testDBShutdown() {
 	cmd := exec.Command("docker", "kill", "postgres-ut")
+	//nolint:errcheck
 	cmd.Run()
 	time.Sleep(time.Second)
 	cmd = exec.Command("docker", "rm", "postgres-ut")
+	//nolint:errcheck
 	cmd.Run()
 }
 

--- a/service/prover/prover/prover.go
+++ b/service/prover/prover/prover.go
@@ -94,6 +94,7 @@ func (p *Prover) ProveBlock() error {
 		if err != nil {
 			return nil, err
 		}
+		//nolint:errcheck
 		defer lock.Release()
 
 		// Fetch unproved block witness.

--- a/service/sender/sender/sender.go
+++ b/service/sender/sender/sender.go
@@ -205,6 +205,7 @@ func (s *Sender) UpdateSentTxs() (err error) {
 			logx.Errorf("query transaction receipt %s failed, err: %v", txHash, err)
 			if time.Now().After(pendingTx.UpdatedAt.Add(time.Duration(s.config.ChainConfig.MaxWaitingTime) * time.Second)) {
 				// No need to check the response, do best effort.
+				//nolint:errcheck
 				s.l1RollupTxModel.DeleteL1RollupTx(pendingTx)
 			}
 			continue

--- a/service/witness/witness/witness.go
+++ b/service/witness/witness/witness.go
@@ -209,7 +209,6 @@ func (w *Witness) RescheduleBlockWitness() {
 			return
 		}
 	}
-	return
 }
 
 func (w *Witness) constructBlockWitness(block *block.Block, latestVerifiedBlockNr int64) (*blockwitness.BlockWitness, error) {


### PR DESCRIPTION
### Description
`make api-server` before running the lint checker.

### Rationale

1. Upgrade golangci linter to version 1.49.0;
2. Fix few lint errors;

### Example
`make lint` to do static checks

### Changes
No