### PR TITLE
fix: fix tests with snapshot postgres db

### DIFF
--- a/service/apiserver/test/getpair_test.go
+++ b/service/apiserver/test/getpair_test.go
@@ -49,7 +49,7 @@ func (s *ApiServerSuite) TestGetPair() {
 }
 
 func GetPair(s *ApiServerSuite, pairIndex int) (int, *types.Pair) {
-	resp, err := http.Get(fmt.Sprintf("%s/api/v1/pair?pair_index=%d", s.url, pairIndex))
+	resp, err := http.Get(fmt.Sprintf("%s/api/v1/pair?index=%d", s.url, pairIndex))
 	assert.NoError(s.T(), err)
 	defer resp.Body.Close()
 

--- a/service/apiserver/test/getswapamount_test.go
+++ b/service/apiserver/test/getswapamount_test.go
@@ -15,7 +15,7 @@ import (
 
 func (s *ApiServerSuite) TestGetSwapAmount() {
 	type args struct {
-		pairIndex   int
+		pairIndex   uint32
 		assetId     uint32
 		assetAmount string
 		isFrom      bool
@@ -36,10 +36,10 @@ func (s *ApiServerSuite) TestGetSwapAmount() {
 		for _, pair := range pairs.Pairs {
 			if pair.TotalLpAmount != "" && pair.TotalLpAmount != "0" {
 				tests = append(tests, []testcase{
-					{"found by index with from is true", args{int(pair.Index), pair.AssetAId, "9000", true}, 200},
-					{"found by index with from is true", args{int(pair.Index), pair.AssetBId, "9000", true}, 200},
-					{"found by index with from is true", args{int(pair.Index), pair.AssetAId, "9000", false}, 200},
-					{"found by index with from is true", args{int(pair.Index), pair.AssetBId, "9000", false}, 200},
+					{"found by index with from is true", args{pair.Index, pair.AssetAId, "9000", true}, 200},
+					{"found by index with from is true", args{pair.Index, pair.AssetBId, "9000", true}, 200},
+					{"found by index with from is false", args{pair.Index, pair.AssetAId, "9000", false}, 200},
+					{"found by index with from is false", args{pair.Index, pair.AssetBId, "9000", false}, 200},
 				}...)
 				break
 			}
@@ -48,7 +48,7 @@ func (s *ApiServerSuite) TestGetSwapAmount() {
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			httpCode, result := GetSwapAmount(s, tt.args.pairIndex)
+			httpCode, result := GetSwapAmount(s, tt.args.pairIndex, tt.args.assetId, tt.args.assetAmount, tt.args.isFrom)
 			assert.Equal(t, tt.httpCode, httpCode)
 			if httpCode == http.StatusOK {
 				assert.NotNil(t, result.AssetId)
@@ -60,8 +60,8 @@ func (s *ApiServerSuite) TestGetSwapAmount() {
 
 }
 
-func GetSwapAmount(s *ApiServerSuite, pairIndex int) (int, *types.SwapAmount) {
-	resp, err := http.Get(fmt.Sprintf("%s/api/v1/swapAmount?pair_index=%d", s.url, pairIndex))
+func GetSwapAmount(s *ApiServerSuite, pairIndex, assetId uint32, assetAmount string, isFrom bool) (int, *types.SwapAmount) {
+	resp, err := http.Get(fmt.Sprintf("%s/api/v1/swapAmount?pair_index=%d&asset_id=%d&asset_amount=%s&is_from=%v", s.url, pairIndex, assetId, assetAmount, isFrom))
 	assert.NoError(s.T(), err)
 	defer resp.Body.Close()
 


### PR DESCRIPTION
### Description

Fix two failed test cases with snapshot postgres db. These two are `getpair_test` and `getswapamount_test`.

### Rationale

Fix wrong testcases of apiserver.

### Example

NA

### Changes

Notable changes:
* update testcases