### PR TITLE
ci: optimize the integration-test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -38,11 +38,16 @@ jobs:
           echo "start deploy new zkbas"
           sudo bash ./deployment/tool/generate_api.sh
           go mod tidy
+          docker image prune -f
           make docker-image
+          cp -r /server/test.keyfile ./deployment/
+          mv ./deployment/test.keyfile ./deployment/.zkbas
           blockNr=$(sudo bash ./deployment/tool/tool.sh blockHeight)
-          sudo bash ./deployment/tool/tool.sh all new
+          sudo bash ./deployment/tool/tool.sh all
           sudo bash ./deployment/docker-compose/docker-compose.sh down
           sudo bash ./deployment/docker-compose/docker-compose.sh up $blockNr
+          echo "Waiting 5m for the initialization tx to be verified"
+          sleep 5m # Waiting for the initialization tx to be verified
           echo "end deploy"
 
       - name: run integration test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,8 +46,8 @@ jobs:
           sudo bash ./deployment/tool/tool.sh all
           sudo bash ./deployment/docker-compose/docker-compose.sh down
           sudo bash ./deployment/docker-compose/docker-compose.sh up $blockNr
-          echo "Waiting 5m for the initialization tx to be verified"
-          sleep 5m # Waiting for the initialization tx to be verified
+          echo "Waiting 10m for the initialization tx to be verified"
+          sleep 10m # Waiting for the initialization tx to be verified
           echo "end deploy"
 
       - name: run integration test

--- a/.github/workflows/issue-trigger.yml
+++ b/.github/workflows/issue-trigger.yml
@@ -1,0 +1,25 @@
+name: Issue Trigger
+
+on:
+  pull_request:
+    types: [opened, edited, closed]
+  issue_comment:                                     
+    types: [created, edited, deleted]
+
+jobs:
+  trigger:
+    runs-on: self-hosted
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: update-integration-keyfile
+        if: contains(github.event.pull_request.body, '/update-integration-keyfile')   # check the comment if it contains the keywords
+        run: |
+          cd /server
+          sudo rm -rf ./zkbas
+          sudo git clone --branch develop https://github.com/bnb-chain/zkbas.git
+          cd ./zkbas
+          sudo bash ./deployment/tool/tool.sh prepare new
+          sudo rm -rf /server/test.keyfile
+          sudo cp -r ./deployment/.zkbas /server/test.keyfile

--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,10 @@
 
 ***/types/types.go
 
-*.vk
-*.pk
-
 **/main
+
+*.pk
+*.vk
 
 build
 vendor

--- a/deployment/tool/tool.sh
+++ b/deployment/tool/tool.sh
@@ -30,11 +30,11 @@ function prepare() {
         go test ./legend/circuit/bn254/solidity -timeout 99999s -run TestExportSol
         mkdir -p $KEY_PATH
         cp -r ./legend/circuit/bn254/solidity/* $KEY_PATH/
-
-        echo 'start verify_parse for ZkbasVerifier ...'
-        cd ${WORKDIR}/../service/prover/
-        python3 verifier_parse.py ${KEY_PATH}/ZkbasVerifier1.sol,${KEY_PATH}/ZkbasVerifier10.sol 1,10 ${WORKDIR}/dependency/zkbas-contract/contracts/ZkbasVerifier.sol
     fi
+
+    echo 'start verify_parse for ZkbasVerifier ...'
+    cd ${WORKDIR}/../service/prover/
+    python3 verifier_parse.py ${KEY_PATH}/ZkbasVerifier1.sol,${KEY_PATH}/ZkbasVerifier10.sol 1,10 ${WORKDIR}/dependency/zkbas-contract/contracts/ZkbasVerifier.sol
 }
 
 function getLatestBlockHeight() {

--- a/deployment/tool/tool.sh
+++ b/deployment/tool/tool.sh
@@ -30,11 +30,11 @@ function prepare() {
         go test ./legend/circuit/bn254/solidity -timeout 99999s -run TestExportSol
         mkdir -p $KEY_PATH
         cp -r ./legend/circuit/bn254/solidity/* $KEY_PATH/
-    fi
 
-    echo 'start verify_parse for ZkbasVerifier ...'
-    cd ${WORKDIR}/../service/prover/
-    python3 verifier_parse.py ${KEY_PATH}/ZkbasVerifier1.sol,${KEY_PATH}/ZkbasVerifier10.sol 1,10 ${WORKDIR}/dependency/zkbas-contract/contracts/ZkbasVerifier.sol
+        echo 'start verify_parse for ZkbasVerifier ...'
+        cd ${WORKDIR}/../service/prover/
+        python3 verifier_parse.py ${KEY_PATH}/ZkbasVerifier1.sol,${KEY_PATH}/ZkbasVerifier10.sol 1,10 ${WORKDIR}/dependency/zkbas-contract/contracts/ZkbasVerifier.sol
+    fi
 }
 
 function getLatestBlockHeight() {


### PR DESCRIPTION
### Description

It is too time-consuming to generate a `keyfile` before executing `integration-test`, so regenerate the `keyfile` only when necessary.

### Rationale

store the `keyfile` in our CI runner, it will copy the files before executing `integration-test`.

### Example

if you need to update `keyfile` in CI runner, please include `/update-integration-keyfile` in the PR description, like.
<img width="287" alt="image" src="https://user-images.githubusercontent.com/25412254/187879965-fab1569f-fca4-4ded-8547-4ac54c7f558b.png">

and the it will trigger action script to update `keyfile` on CI runner.

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/25412254/187880136-25782cfd-a3e5-4c5c-a32a-3134093fe61c.png">

### Changes

Notable changes:
* github action scripts.

### Trigger
/update-integration-keyfile
