### PR TITLE
core: add offer id check for cancel offer executor

### DIFF
--- a/core/executor/cancel_offer_executor.go
+++ b/core/executor/cancel_offer_executor.go
@@ -70,6 +70,16 @@ func (e *CancelOfferExecutor) VerifyInputs() error {
 		return errors.New("balance is not enough")
 	}
 
+	offerAssetId := txInfo.OfferId / 128
+	offerIndex := txInfo.OfferId % 128
+	offerAsset := e.bc.StateDB().AccountMap[txInfo.AccountIndex].AssetInfo[offerAssetId]
+	if offerAsset != nil && offerAsset.OfferCanceledOrFinalized != nil {
+		xBit := offerAsset.OfferCanceledOrFinalized.Bit(int(offerIndex))
+		if xBit == 1 {
+			return errors.New("invalid offer id, already confirmed or canceled")
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### Description

Currently, if the offer id has been canceled/matched, user can re-submit cancel offer without error when sending the request. It could be confused. So, in this pr, user's cancel offer id will be validated when sending requests.

### Rationale

Enhance cancel offer validation.

### Example

NA

### Changes

Notable changes:
* NA