### PR TITLE
ci: use blocksize 1 to reduce the integration time

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,8 +46,8 @@ jobs:
           sudo bash ./deployment/tool/tool.sh all
           sudo bash ./deployment/docker-compose/docker-compose.sh down
           sudo bash ./deployment/docker-compose/docker-compose.sh up $blockNr
-          echo "Waiting 10m for the initialization tx to be verified"
-          sleep 10m # Waiting for the initialization tx to be verified
+          echo "Waiting 3m for the initialization tx to be verified"
+          sleep 3m # Waiting for the initialization tx to be verified
           echo "end deploy"
 
       - name: run integration test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,8 +40,8 @@ jobs:
           go mod tidy
           docker image prune -f
           make docker-image
-          cp -r /server/test.keyfile ./deployment/
-          mv ./deployment/test.keyfile ./deployment/.zkbas
+          sudo cp -r /server/test.keyfile ./deployment/
+          sudo mv ./deployment/test.keyfile ./deployment/.zkbas
           blockNr=$(sudo bash ./deployment/tool/tool.sh blockHeight)
           sudo bash ./deployment/tool/tool.sh all
           sudo bash ./deployment/docker-compose/docker-compose.sh down

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,8 +40,8 @@ jobs:
           go mod tidy
           docker image prune -f
           make docker-image
-          sudo cp -r /server/test.keyfile ./deployment/
-          sudo mv ./deployment/test.keyfile ./deployment/.zkbas
+          sudo mkdir -p ./deployment/.zkbas
+          sudo cp /server/test.keyfile/* ./deployment/.zkbas
           blockNr=$(sudo bash ./deployment/tool/tool.sh blockHeight)
           sudo bash ./deployment/tool/tool.sh all
           sudo bash ./deployment/docker-compose/docker-compose.sh down

--- a/deployment/docker-compose/docker-compose.sh
+++ b/deployment/docker-compose/docker-compose.sh
@@ -28,11 +28,11 @@ CacheRedis:
     Type: node
 
 KeyPath:
-  ProvingKeyPath: [/server/.zkbas/zkbas1.pk, /server/.zkbas/zkbas10.pk]
-  VerifyingKeyPath: [/server/.zkbas/zkbas1.vk, /server/.zkbas/zkbas10.vk]
+  ProvingKeyPath: [/server/.zkbas/zkbas1.pk]
+  VerifyingKeyPath: [/server/.zkbas/zkbas1.vk]
 
 BlockConfig:
-  OptionalBlockSizes: [1, 10]
+  OptionalBlockSizes: [1]
 " > ${CONFIG_PATH}/prover.yaml
 
 echo -e "

--- a/deployment/docker-compose/docker-compose.sh
+++ b/deployment/docker-compose/docker-compose.sh
@@ -78,7 +78,7 @@ CacheRedis:
     Type: node
 
 BlockConfig:
-  OptionalBlockSizes: [1, 10]
+  OptionalBlockSizes: [1]
 
 TreeDB:
   Driver: memorydb


### PR DESCRIPTION
### Description
The current CI integration test takes more than 40 minutes, it is because of the proof generation time. 
This PR aims to reduce the time.

### Rationale
We change the CI block size from 10 to 1 to reduce the integration time.

### Example
No

### Changes
It is transparent to users.