### PR TITLE
fix: handle price query when token not listed on cmc, add lp in accou…

### DIFF
--- a/service/apiserver/internal/logic/account/getaccountlogic.go
+++ b/service/apiserver/internal/logic/account/getaccountlogic.go
@@ -78,8 +78,12 @@ func (l *GetAccountLogic) GetAccount(req *types.ReqGetAccount) (resp *types.Acco
 		Assets: make([]*types.AccountAsset, 0),
 	}
 	for _, asset := range account.AssetInfo {
-		if asset.AssetId > maxAssetId || asset.Balance == nil || asset.Balance.Cmp(big.NewInt(0)) == 0 {
-			continue //it is used for offer related, or empty balance
+		if asset.AssetId > maxAssetId {
+			continue //it is used for offer related, or empty balance; max ip id should be less than max asset id
+		}
+		if (asset.Balance == nil || asset.Balance.Cmp(big.NewInt(0)) == 0) &&
+			(asset.LpAmount == nil || asset.LpAmount.Cmp(big.NewInt(0)) == 0) {
+			continue
 		}
 		assetName, _ := l.svcCtx.MemCache.GetAssetNameById(asset.AssetId)
 		resp.Assets = append(resp.Assets, &types.AccountAsset{

--- a/types/code.go
+++ b/types/code.go
@@ -28,6 +28,8 @@ var (
 
 	IoErrFailToRead = errors.New("ioutil.ReadAll err")
 
+	CmcNotListedErr = errors.New("cmc not listed")
+
 	AppErrInvalidParam    = New(20001, "invalid param: ")
 	AppErrInvalidTx       = New(20002, "invalid tx: cannot parse tx")
 	AppErrInvalidTxType   = New(20003, "invalid tx type")


### PR DESCRIPTION
### Description

This pr fixes two issues in apiserver: 1) return zero price when the token cannot be found in CMC; 2) return lp amount in account api.

### Rationale
Previous the price query did not handling this case, and account api did return the lp amounts.

### Example

NA

### Changes

Notable changes:
* update handlers