### PR TITLE
deployment ci: fix tool.sh and trigger update-integration-keyfile from PR branch 

### DIFF
--- a/.github/workflows/issue-trigger.yml
+++ b/.github/workflows/issue-trigger.yml
@@ -18,8 +18,16 @@ jobs:
         run: |
           cd /server
           sudo rm -rf ./zkbas
-          sudo git clone --branch develop https://github.com/bnb-chain/zkbas.git
+          
+          echo 'fetch zkbas repo'
+          export PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+          echo Pull requests $PR_NUMBER
+          
+          sudo git clone https://github.com/bnb-chain/zkbas.git
           cd ./zkbas
+          sudo git fetch origin pull/$PR_NUMBER/head:$GITHUB_SHA 2>/dev/null
+          sudo git checkout $GITHUB_SHA
+
           sudo bash ./deployment/tool/tool.sh prepare new
           sudo rm -rf /server/test.keyfile
           sudo cp -r ./deployment/.zkbas /server/test.keyfile

--- a/deployment/tool/tool.sh
+++ b/deployment/tool/tool.sh
@@ -11,7 +11,7 @@ KEY_PATH=${WORKDIR}/.zkbas
 ZKBAS_CONTRACT_REPO=https://github.com/bnb-chain/zkbas-contract.git
 ZKBAS_CRYPTO_REPO=https://github.com/bnb-chain/zkbas-crypto.git
 BSC_TESTNET_ENDPOINT=https://data-seed-prebsc-1-s1.binance.org:8545
-ZKBAS_CRYPTO_BRANCH=$(cat $WORKDIR/../go.mod | grep github.com/bnb-chain/zkbas-crypto | awk -F" " '{print $2}')
+ZKBAS_CRYPTO_BRANCH=$(cat $WORKDIR/../go.mod | grep github.com/bnb-chain/zkbas-crypto | awk -F" " '{print $2}' | awk -F"-" '{if ($3 != "") print $3;else print $1;}')
 
 export PATH=$PATH:/usr/local/go/bin:/usr/local/go/bin:/root/go/bin
 
@@ -21,7 +21,8 @@ function prepare() {
     mkdir -p ${WORKDIR}/dependency && cd ${WORKDIR}/dependency
 
     git clone --branch develop ${ZKBAS_CONTRACT_REPO}
-    git clone --branch ${ZKBAS_CRYPTO_BRANCH} ${ZKBAS_CRYPTO_REPO}
+    git clone --branch develop ${ZKBAS_CRYPTO_REPO}
+    cd ${WORKDIR}/dependency/zkbas-crypto && git checkout ${ZKBAS_CRYPTO_BRANCH}
 
     if [ ! -z $1 ] && [ "$1" = "new" ]; then
         echo "new crypto env"


### PR DESCRIPTION
### Description

1. fix the branch parser of crypto repo
2. trigger update-integration-keyfile from PR branch

### Rationale

1. parse `github.com/bnb-chain/zkbas-crypto` branch from go.mod
2. checkout to PR branch before running keygen tool

### Example

N/A

### Changes

Notable changes:
* tools


/update-integration-keyfile